### PR TITLE
Build: sdcc: use sdcc official build of cc1 since it already has libisl and libzstd statically linked

### DIFF
--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -127,7 +127,7 @@ jobs:
           # Move cc1 to it's special hardwired path
           mkdir libexec
           mkdir libexec/sdcc
-          if: (matrix.name == 'MacOS-x64')
+          if [ "${{ matrix.name }}" = "MacOS-x64" ]; then
             # Special case - use sdcc official build of cc1 since it has static linkage for libisl, libzstd (had some trouble with that on this build)
             # this will untar into libexec/sdcc/cc1
             curl -Lo macos-cc1.tar.gz https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/sdcc-extras/sdcc-4.3-macos-cc1-14110.tar.gz

--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -123,11 +123,18 @@ jobs:
           # remove .in mapping files, etc
           rm -f bin/*.in
           rm -f bin/Makefile
-          rm -f bin/README          
+          rm -f bin/README
           # Move cc1 to it's special hardwired path
           mkdir libexec
           mkdir libexec/sdcc
-          mv bin/cc1 libexec/sdcc
+          if: (matrix.name == 'MacOS-x64')
+            # Special case - use sdcc official build of cc1 since it has static linkage for libisl, libzstd (had some trouble with that on this build)
+            # this will untar into libexec/sdcc/cc1
+            curl -Lo macos-cc1.tar.gz https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/sdcc-extras/sdcc-4.3-macos-cc1-14110.tar.gz
+            tar xvfz macos-cc1.tar.gz
+          else
+            mv bin/cc1 libexec/sdcc
+          fi
           ls -la bin
           cd ../..
 


### PR DESCRIPTION
Don't need any patches to it so far, so easier to just use their version