### PR TITLE
Add macOS Arm support

### DIFF
--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -34,14 +34,16 @@ jobs:
             name: Win32-On-Linux
           - os: ubuntu-20.04
             name: Win64-On-Linux
-          - os: macos-11
+          - os: macos-13
             name: MacOS-x64
+          - os: macos-14
+            name: MacOS-arm64            
     steps:
       # ==== Pre-Build: Set environment vars ====
       # Needs to be in a separate step than build so that setting the environment var takes effect
       #
       - name: Pre-Build Linux/MacOS
-        if: (matrix.name == 'Linux-x64') || (matrix.name == 'MacOS-x64') || (matrix.name == 'Win32-On-Linux') || (matrix.name == 'Win64-On-Linux')
+        if: (matrix.name == 'Linux-x64') || (matrix.name == 'MacOS-x64') || (matrix.name == 'MacOS-arm64') || (matrix.name == 'Win32-On-Linux') || (matrix.name == 'Win64-On-Linux')
         shell: bash
         run: |
           echo "SDCC_VER=${{ inputs.sdcc_version_num }}" >> $GITHUB_ENV
@@ -55,10 +57,10 @@ jobs:
           sudo apt-get install flex bison libboost-dev texinfo zlib1g zlib1g-dev
 
       - name: Install Dependencies MacOS 64
-        if: (matrix.name == 'MacOS-x64')
+        if: (matrix.name == 'MacOS-x64') || (matrix.name == 'MacOS-arm64')
         run: |
           # Packages (some may already be present)
-          brew install flex bison boost texinfo zlib subversion
+          env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install flex bison boost texinfo zlib subversion
 
       # This could be split apart to separate 32 and 64 bit, but doesn't
       # take much time and is easier to keep in sync as one stage.
@@ -86,7 +88,7 @@ jobs:
 
       # ==== Download SDCC sources ====
       - name: Download SDCC Sources
-        if: (matrix.name == 'Linux-x64') || (matrix.name == 'MacOS-x64') || (matrix.name == 'Win32-On-Linux') || (matrix.name == 'Win64-On-Linux')
+        if: (matrix.name == 'Linux-x64') || (matrix.name == 'MacOS-x64') || (matrix.name == 'MacOS-arm64') || (matrix.name == 'Win32-On-Linux') || (matrix.name == 'Win64-On-Linux')
         run: |
           # Checkout SDCC source
           svn checkout -q -r ${{ env.SDCC_VER }} svn://svn.code.sf.net/p/sdcc/code/trunk sdcc-${{ env.SDCC_VER }}
@@ -105,9 +107,17 @@ jobs:
 
       # ==== Build SDCC Linux / MacOS ====
       - name: Build SDCC Linux / MacOS
-        if: (matrix.name == 'Linux-x64') || (matrix.name == 'MacOS-x64')
+        if: (matrix.name == 'Linux-x64') || (matrix.name == 'MacOS-x64') || (matrix.name == 'MacOS-arm64')
         shell: bash
         run: |    
+          if [ "${{ matrix.name }}" = "MacOS-arm64" ]; then
+            # MacOS arm64 homebrew installs libs to /opt/homebrew rather than /usr/local so set LDFLAGS/CPPFLAGS
+            # Clang seems to always use dynamic libraries where available to so copying static libraries to another folder
+            sudo mkdir /opt/homebrew/lib-static
+            sudo cp -r /opt/homebrew/lib/*.a /opt/homebrew/lib-static
+            export LDFLAGS="-L/opt/homebrew/lib-static"
+            export CPPFLAGS="-I/opt/homebrew/include"
+          fi
           # Target older macOS version than whatever build OS is for better compatibility (Linux should ignore this)
           export MACOSX_DEPLOYMENT_TARGET=10.10
           cd sdcc-${{ env.SDCC_VER }}/sdcc
@@ -225,7 +235,7 @@ jobs:
 
       # ==== Packaging ====
       - name: Package build Linux/MacOS
-        if: (matrix.name == 'Linux-x64') || (matrix.name == 'MacOS-x64') || (matrix.name == 'Win32-On-Linux') || (matrix.name == 'Win64-On-Linux')
+        if: (matrix.name == 'Linux-x64') || (matrix.name == 'MacOS-x64') || (matrix.name == 'MacOS-arm64') || (matrix.name == 'Win32-On-Linux') || (matrix.name == 'Win64-On-Linux')
         shell: bash
         run: |
           cd sdcc-${{ env.SDCC_VER }}
@@ -235,7 +245,7 @@ jobs:
           ls -la
 
       - name: Store build
-        if: (matrix.name == 'Linux-x64') || (matrix.name == 'MacOS-x64') || (matrix.name == 'Win32-On-Linux') || (matrix.name == 'Win64-On-Linux')
+        if: (matrix.name == 'Linux-x64') || (matrix.name == 'MacOS-x64') || (matrix.name == 'MacOS-arm64') || (matrix.name == 'Win32-On-Linux') || (matrix.name == 'Win64-On-Linux')
         uses: actions/upload-artifact@v4
         with:
           name: sdcc-${{ inputs.sdcc_version_num }}-${{ matrix.name }}-build


### PR DESCRIPTION
I'm working on updating GB Studio to support M1/M2/M3 Macs natively, noticed that the gbdk-2020 main repo fetches sdcc builds from this repo so just wanted to add Mac arm64 support (I can make a PR into gbdk-2020 main repo if you're happy with this change)

- Github actions added arm64 support with the `macos-14` runners so I've added that to the matrix https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
- Homebrew on arm64 installs to a different directory by default (`/opt/homebrew`) so I've had to set LDFLAGS and CPPFLAGS just for macos-14
- I was getting link problems for libisl, libzstd, sounds like you had similar on Mac x64 based on the comments but the fix of using the official cc1 build I don't think could work here as I couldn't find an official Mac arm build of cc1. Seems like clang will always prefer to use dynamic libraries when available, to fix this I copied all the static libraries to a different folder and set LDFLAGS to point to that instead. Not sure if that's a good idea or not but seemed to work. I left the Mac x64 build fix as is, but if you're happy with this I could submit another PR to do a similar fix for that build
- I noticed the Mac x64 build was timing out, it turns out  homebrew dropped support for prebuilt `boost` libraries on macos-11 at some point very recently so it was trying to compile from source adding 30 minutes to the build time for Mac x64 which would 50/50 chance timeout. The fix was to update to using `macos-13` for the x64 build which was the last macOS that GitHub actions uses Intel based runners for
- The x64 update to using `macos-13` then introduced an issue where homebrew tried to install python3 after completing the brew install step and was clashing with a version already installed by the os, the fix for this was to set the environment variable `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1`

You can see the result of running this updated action here https://github.com/chrismaltby/gbdk-2020-sdcc/actions/
I've rebuilt GBDK-2020 using the SDCC build from running these actions and all seems to be working, I've also tested this running builds from GB Studio.