### PR TITLE
MacOS: manual build boost 1.83.0 + sdcc 14878

### DIFF
--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -128,11 +128,11 @@ jobs:
             export LDFLAGS="-L/opt/homebrew/lib-static"
             export CPPFLAGS="-I/opt/homebrew/include"
             # Add manually installed boost
-            export DYLD_LIBRARY_PATH=/usr/local/boost-1.83.0/lib:$DYLD_LIBRARY_PATH            
+            export DYLD_LIBRARY_PATH=/usr/local/boost-1.83.0:$DYLD_LIBRARY_PATH            
           fi
           if [ "${{ matrix.name }}" = "MacOS-x64" ]; then
             # Add manually installed boost          
-            export DYLD_LIBRARY_PATH=/usr/local/boost-1.83.0/lib:$DYLD_LIBRARY_PATH          
+            export DYLD_LIBRARY_PATH=/usr/local/boost-1.83.0:$DYLD_LIBRARY_PATH          
           fi
           # Target older macOS version than whatever build OS is for better compatibility (Linux should ignore this)
           export MACOSX_DEPLOYMENT_TARGET=10.10

--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -66,8 +66,11 @@ jobs:
           # No boost 1.85.0 via homebrew since it brak sdcc
           env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install flex bison texinfo zlib subversion
           # manual boost install with Clang
+          wget https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz -O- | tar xfz -
+          cd boost*
           ./bootstrap.sh --prefix=/usr/local/boost-1.83.0
           sudo ./b2 cxxflags=-std=c++17 install
+          cd ..
 
       # This could be split apart to separate 32 and 64 bit, but doesn't
       # take much time and is easier to keep in sync as one stage.

--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -30,12 +30,12 @@ jobs:
     strategy:
       matrix:
         include:
-#          - os: ubuntu-20.04
-#            name: Linux-x64
-#          - os: ubuntu-20.04
-#            name: Win32-On-Linux
-#          - os: ubuntu-20.04
-#            name: Win64-On-Linux
+          - os: ubuntu-20.04
+            name: Linux-x64
+          - os: ubuntu-20.04
+            name: Win32-On-Linux
+          - os: ubuntu-20.04
+            name: Win64-On-Linux
           - os: macos-13
             name: MacOS-x64
           - os: macos-14

--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -68,7 +68,7 @@ jobs:
           # manual boost install with Clang
           wget https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz -O- | tar xfz -
           cd boost*
-          ./bootstrap.sh --prefix=/usr/local/boost-1.83.0
+          ./bootstrap.sh --prefix=/usr/local
           sudo ./b2 cxxflags=-std=c++17 install
           cd ..
 
@@ -128,11 +128,13 @@ jobs:
             export LDFLAGS="-L/opt/homebrew/lib-static"
             export CPPFLAGS="-I/opt/homebrew/include"
             # Add manually installed boost
-            export DYLD_LIBRARY_PATH=/usr/local/boost-1.83.0:$DYLD_LIBRARY_PATH            
+            export DYLD_LIBRARY_PATH=/usr/local:$DYLD_LIBRARY_PATH
+            export BOOST_ROOT=/usr/local
           fi
           if [ "${{ matrix.name }}" = "MacOS-x64" ]; then
             # Add manually installed boost          
-            export DYLD_LIBRARY_PATH=/usr/local/boost-1.83.0:$DYLD_LIBRARY_PATH          
+            export DYLD_LIBRARY_PATH=/usr/local:$DYLD_LIBRARY_PATH
+            export BOOST_ROOT=/usr/local
           fi
           # Target older macOS version than whatever build OS is for better compatibility (Linux should ignore this)
           export MACOSX_DEPLOYMENT_TARGET=10.10

--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -11,7 +11,7 @@ on:
     inputs:
       sdcc_version_num:
         description: 'SDCC Version Number (ex: 13911, 14089, 14228, 14581, 14635)'
-        default: '14865'
+        default: '14878'
         required: true
         type: string
       sdcc_patch_file_url:
@@ -30,16 +30,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
-            name: Linux-x64
-          - os: ubuntu-20.04
-            name: Win32-On-Linux
-          - os: ubuntu-20.04
-            name: Win64-On-Linux
-#          - os: macos-13
-#            name: MacOS-x64
-#          - os: macos-14
-#            name: MacOS-arm64            
+#          - os: ubuntu-20.04
+#            name: Linux-x64
+#          - os: ubuntu-20.04
+#            name: Win32-On-Linux
+#          - os: ubuntu-20.04
+#            name: Win64-On-Linux
+          - os: macos-13
+            name: MacOS-x64
+          - os: macos-14
+            name: MacOS-arm64            
     steps:
       # ==== Pre-Build: Set environment vars ====
       # Needs to be in a separate step than build so that setting the environment var takes effect
@@ -62,7 +62,12 @@ jobs:
         if: (matrix.name == 'MacOS-x64') || (matrix.name == 'MacOS-arm64')
         run: |
           # Packages (some may already be present)
-          env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install flex bison boost texinfo zlib subversion
+          # env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install flex bison boost texinfo zlib subversion
+          # No boost 1.85.0 via homebrew since it brak sdcc
+          env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install flex bison texinfo zlib subversion
+          # manual boost install with Clang
+          ./bootstrap.sh --prefix=/usr/local/boost-1.83.0
+          sudo ./b2 cxxflags=-std=c++17 install
 
       # This could be split apart to separate 32 and 64 bit, but doesn't
       # take much time and is easier to keep in sync as one stage.

--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -127,6 +127,12 @@ jobs:
             sudo cp -r /opt/homebrew/lib/*.a /opt/homebrew/lib-static
             export LDFLAGS="-L/opt/homebrew/lib-static"
             export CPPFLAGS="-I/opt/homebrew/include"
+            # Add manually installed boost
+            export DYLD_LIBRARY_PATH=/usr/local/boost-1.83.0/lib:$DYLD_LIBRARY_PATH            
+          fi
+          if [ "${{ matrix.name }}" = "MacOS-x64" ]; then
+            # Add manually installed boost          
+            export DYLD_LIBRARY_PATH=/usr/local/boost-1.83.0/lib:$DYLD_LIBRARY_PATH          
           fi
           # Target older macOS version than whatever build OS is for better compatibility (Linux should ignore this)
           export MACOSX_DEPLOYMENT_TARGET=10.10

--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -36,10 +36,10 @@ jobs:
             name: Win32-On-Linux
           - os: ubuntu-20.04
             name: Win64-On-Linux
-          - os: macos-13
-            name: MacOS-x64
-          - os: macos-14
-            name: MacOS-arm64            
+#          - os: macos-13
+#            name: MacOS-x64
+#          - os: macos-14
+#            name: MacOS-arm64            
     steps:
       # ==== Pre-Build: Set environment vars ====
       # Needs to be in a separate step than build so that setting the environment var takes effect


### PR DESCRIPTION
Workaround boost 1.85.0 bugs that break sdcc. Only other version in homebrew is marked deprecated. So manually build it instead (since mixing in macports is not recommended).
- See: https://sourceforge.net/p/sdcc/bugs/3739/
  - PKK: "Boost has fixed the bug, so the fix will be in their next release. I've added a test in SDCC to make it fail to compile with boost 1.85.0, and report an error explaining the situation." (i.e, 1.89 on Homebrew should be ok)

Rev to sdcc 14878 to fix z80/sm83 codegen issue: https://sourceforge.net/p/sdcc/bugs/3740/