### PR TITLE
SDCC 4.5.0, non-merged gbdk patchs

### DIFF
--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -23,7 +23,7 @@ on:
         # default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/gbdk-4.2-nes_banked_nonbanked_no_overlay_locals_v6_combined.diff.patch'
         # (14635) # default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/gbdk-4.3.0-nes_banked_nonbanked_no_overlay_locals_v7_combined.diff.patch'
         # (14650) # default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/gbdk-4.3-nes_banked_nonbanked_no_overlay_locals_v8_combined.patch'
-        default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/sdcc_15224__gbdk_4.4.0_patches_v9-pre_individual.zip'
+        default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/sdcc_15224__gbdk_4.4.0_patches_v9_individual.zip'
         type: string        
 jobs:
   build:

--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -10,8 +10,8 @@ on:
   #   branches: [ develop ]
     inputs:
       sdcc_version_num:
-        description: 'SDCC Version Number (ex: 13911, 14089, 14228, 14581, 14635,14880)'
-        default: '14650'
+        description: 'SDCC Version Number (ex: 15224)'
+        default: '15224'
         required: true
         type: string
       sdcc_patch_file_url:
@@ -22,7 +22,8 @@ on:
         # default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/gbdk-4.2-nes_banked_nonbanked_v4_combined.diff.patch'
         # default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/gbdk-4.2-nes_banked_nonbanked_no_overlay_locals_v6_combined.diff.patch'
         # (14635) # default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/gbdk-4.3.0-nes_banked_nonbanked_no_overlay_locals_v7_combined.diff.patch'
-        default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/gbdk-4.3-nes_banked_nonbanked_no_overlay_locals_v8_combined.patch'
+        # (14650) # default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/gbdk-4.3-nes_banked_nonbanked_no_overlay_locals_v8_combined.patch'
+        default: 'https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/download/patches/sdcc_15224__gbdk_4.4.0_patches_v9-pre_individual.zip'
         type: string        
 jobs:
   build:
@@ -57,8 +58,12 @@ jobs:
       - name: Install Dependencies Linux
         if: (matrix.name == 'Linux-x64') || (matrix.name == 'Linux-arm64') 
         run: |
+          #  SDCC Blocks buggy boosts version boost 1.71-1.79.0, often present on ubuntu
+          sudo add-apt-repository ppa:mhier/libboost-latest
+          sudo apt update
+          sudo apt-get -y --purge remove libboost-all-dev libboost-doc libboost-dev
           # Packages (some may already be present)
-          sudo apt-get install flex bison libboost-dev texinfo zlib1g zlib1g-dev
+          sudo apt-get install flex bison boost1.81-dev texinfo zlib1g zlib1g-dev
 
       - name: Install Dependencies MacOS 64
         if: (matrix.name == 'MacOS-x64') || (matrix.name == 'MacOS-arm64')
@@ -79,8 +84,12 @@ jobs:
       - name: Install Dependencies WinCross
         if: (matrix.name == 'Win32-On-Linux') || (matrix.name == 'Win64-On-Linux')
         run: |
+          #  SDCC Blocks buggy boosts version boost 1.71-1.79.0, often present on ubuntu
+          sudo add-apt-repository ppa:mhier/libboost-latest
+          sudo apt update
+          sudo apt-get -y --purge remove libboost-all-dev libboost-doc libboost-dev
           # Packages (some may already be present)
-          sudo apt-get -y install flex bison libboost-dev texinfo zlib1g zlib1g-dev g++ make mingw-w64 gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 subversion
+          sudo apt-get -y install flex bison boost1.81-dev texinfo zlib1g zlib1g-dev g++ make mingw-w64 gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 subversion
           sudo ln -s /usr/include/boost/ /usr/x86_64-w64-mingw32/include
           sudo ln -s /usr/include/boost/ /usr/i686-w64-mingw32/include
           # Zlib missing for mingw 64 bit (might be an easier way than this)
@@ -101,7 +110,9 @@ jobs:
       # ==== Download SDCC sources ====
       - name: Download SDCC Sources
         if: (matrix.name == 'Linux-x64') || (matrix.name == 'Linux-arm64') || (matrix.name == 'MacOS-x64') || (matrix.name == 'MacOS-arm64') || (matrix.name == 'Win32-On-Linux') || (matrix.name == 'Win64-On-Linux')
-        run: |
+        run: |    
+          # Try not to hammer the svn server too much at once, stagger matrix jobs a bit
+          sleep $((60 * ${{ strategy.job-index }} ))
           # Checkout SDCC source
           svn checkout -q -r ${{ env.SDCC_VER }} svn://svn.code.sf.net/p/sdcc/code/trunk sdcc-${{ env.SDCC_VER }}
           # Apply patch file to source of applicable
@@ -111,8 +122,9 @@ jobs:
             echo "Patch sdcc: ${{ inputs.sdcc_patch_file_url }}"
             # cd sdcc-${{ env.SDCC_VER }}/sdcc
             cd sdcc-${{ env.SDCC_VER }}
-            curl -Lo gbdk-sdcc-patch-file ${{ inputs.sdcc_patch_file_url }}
-            patch -p0 -f < gbdk-sdcc-patch-file
+            curl -Lo gbdk-sdcc-patch-files.zip ${{ inputs.sdcc_patch_file_url }}
+            unzip gbdk-sdcc-patch-files.zip
+            for file in $(ls -v *.patch); do echo "$file"; patch -p0 -f < "$file"; done
             # cd ../..
             cd ..
           fi   

--- a/Patches/0100_at_15224_sdcc_mos6502_underscored_segments.patch
+++ b/Patches/0100_at_15224_sdcc_mos6502_underscored_segments.patch
@@ -1,0 +1,609 @@
+Index: sdcc/device/lib/mos6502/__sdcc_indirect_jsr.s
+===================================================================
+--- sdcc/device/lib/mos6502/__sdcc_indirect_jsr.s	(revision 14868)
++++ sdcc/device/lib/mos6502/__sdcc_indirect_jsr.s	(working copy)
+@@ -1,3 +1,3 @@
+-.area CODE
++.area _CODE
+ __sdcc_indirect_jsr::
+ 	jmp	[REGTEMP]
+Index: sdcc/device/lib/mos6502/_divsint.s
+===================================================================
+--- sdcc/device/lib/mos6502/_divsint.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_divsint.s	(working copy)
+@@ -47,7 +47,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ __divsint:
+ 	jsr	___sdivmod16
+Index: sdcc/device/lib/mos6502/_divslong.s
+===================================================================
+--- sdcc/device/lib/mos6502/_divslong.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_divslong.s	(working copy)
+@@ -50,7 +50,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ __divslong:
+ 	jsr	___sdivmod32
+ 	lda	*s1
+Index: sdcc/device/lib/mos6502/_divuchar.s
+===================================================================
+--- sdcc/device/lib/mos6502/_divuchar.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_divuchar.s	(working copy)
+@@ -45,7 +45,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ __divuchar:
+ 	stx	*__divuint_PARM_2
+ 	ldx	#0x00
+Index: sdcc/device/lib/mos6502/_divuint.s
+===================================================================
+--- sdcc/device/lib/mos6502/_divuint.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_divuint.s	(working copy)
+@@ -61,7 +61,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ __divuint:
+ 	jsr	___udivmod16
+Index: sdcc/device/lib/mos6502/_divulong.s
+===================================================================
+--- sdcc/device/lib/mos6502/_divulong.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_divulong.s	(working copy)
+@@ -73,7 +73,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ __divulong:
+ 	jsr	___udivmod32
+Index: sdcc/device/lib/mos6502/_memcmp.s
+===================================================================
+--- sdcc/device/lib/mos6502/_memcmp.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_memcmp.s	(working copy)
+@@ -56,7 +56,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 	
+ ;--------------------------------------------------------
+ ; int memcmp (int *s1, int *s2, int count)
+Index: sdcc/device/lib/mos6502/_memset.s
+===================================================================
+--- sdcc/device/lib/mos6502/_memset.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_memset.s	(working copy)
+@@ -57,7 +57,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ _memset:
+ 	sta	*save+0
+Index: sdcc/device/lib/mos6502/_modsint.s
+===================================================================
+--- sdcc/device/lib/mos6502/_modsint.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_modsint.s	(working copy)
+@@ -46,7 +46,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ __modsint:
+ 	jsr 	___sdivmod16
+Index: sdcc/device/lib/mos6502/_modslong.s
+===================================================================
+--- sdcc/device/lib/mos6502/_modslong.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_modslong.s	(working copy)
+@@ -49,7 +49,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ __modslong:
+ 	jsr	___sdivmod32
+ 	lda	*s1
+Index: sdcc/device/lib/mos6502/_moduchar.s
+===================================================================
+--- sdcc/device/lib/mos6502/_moduchar.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_moduchar.s	(working copy)
+@@ -45,7 +45,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ __moduchar:
+ 	stx	*__moduint_PARM_2
+ 	ldx	#0x00
+Index: sdcc/device/lib/mos6502/_moduint.s
+===================================================================
+--- sdcc/device/lib/mos6502/_moduint.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_moduint.s	(working copy)
+@@ -45,7 +45,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 	
+ __moduint:
+ 	jsr 	___udivmod16
+Index: sdcc/device/lib/mos6502/_modulong.s
+===================================================================
+--- sdcc/device/lib/mos6502/_modulong.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_modulong.s	(working copy)
+@@ -48,7 +48,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ __modulong:
+ 	jsr 	___udivmod32
+Index: sdcc/device/lib/mos6502/_mulint.s
+===================================================================
+--- sdcc/device/lib/mos6502/_mulint.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_mulint.s	(working copy)
+@@ -50,7 +50,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ __mulint:
+ 	sta	*___SDCC_m6502_ret0
+Index: sdcc/device/lib/mos6502/_mullong.s
+===================================================================
+--- sdcc/device/lib/mos6502/_mullong.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_mullong.s	(working copy)
+@@ -57,7 +57,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ __mullong:
+ 
+Index: sdcc/device/lib/mos6502/_mulschar.s
+===================================================================
+--- sdcc/device/lib/mos6502/_mulschar.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_mulschar.s	(working copy)
+@@ -52,7 +52,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ __mulschar:
+ 	sta	*s1
+Index: sdcc/device/lib/mos6502/_muluchar.s
+===================================================================
+--- sdcc/device/lib/mos6502/_muluchar.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_muluchar.s	(working copy)
+@@ -49,7 +49,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ __muluchar:
+ 	sta     *arg1
+Index: sdcc/device/lib/mos6502/_ret01.s
+===================================================================
+--- sdcc/device/lib/mos6502/_ret01.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_ret01.s	(working copy)
+@@ -3,7 +3,7 @@
+ ;--------------------------------------------------------
+ ; ZP ram data
+ ;--------------------------------------------------------
+-	.area ZP      (PAG)
++	.area _ZP      (PAG)
+ ___SDCC_m6502_ret0::
+ 	.ds 1
+ ___SDCC_m6502_ret1::
+Index: sdcc/device/lib/mos6502/_ret23.s
+===================================================================
+--- sdcc/device/lib/mos6502/_ret23.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_ret23.s	(working copy)
+@@ -3,7 +3,7 @@
+ ;--------------------------------------------------------
+ ; ZP ram data
+ ;--------------------------------------------------------
+-	.area ZP      (PAG)
++	.area _ZP      (PAG)
+ ___SDCC_m6502_ret2::
+ 	.ds 1
+ ___SDCC_m6502_ret3::
+Index: sdcc/device/lib/mos6502/_ret4567.s
+===================================================================
+--- sdcc/device/lib/mos6502/_ret4567.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_ret4567.s	(working copy)
+@@ -3,7 +3,7 @@
+ ;--------------------------------------------------------
+ ; ZP ram data
+ ;--------------------------------------------------------
+-	.area ZP      (PAG)
++	.area _ZP      (PAG)
+ ___SDCC_m6502_ret4::
+ 	.ds 1
+ ___SDCC_m6502_ret5::
+Index: sdcc/device/lib/mos6502/_setjmp.s
+===================================================================
+--- sdcc/device/lib/mos6502/_setjmp.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_setjmp.s	(working copy)
+@@ -52,7 +52,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-        .area CODE
++        .area _CODE
+ 
+ ;------------------------------------------------------------
+ ; int __setjmp (jmp_buf buf)
+Index: sdcc/device/lib/mos6502/_strcmp.s
+===================================================================
+--- sdcc/device/lib/mos6502/_strcmp.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_strcmp.s	(working copy)
+@@ -50,7 +50,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ _strcmp:
+ 	sta	*_str1+0
+Index: sdcc/device/lib/mos6502/_strcpy.s
+===================================================================
+--- sdcc/device/lib/mos6502/_strcpy.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_strcpy.s	(working copy)
+@@ -51,7 +51,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ _strcpy:
+ 	sta	*_dst+0
+Index: sdcc/device/lib/mos6502/_strlen.s
+===================================================================
+--- sdcc/device/lib/mos6502/_strlen.s	(revision 14868)
++++ sdcc/device/lib/mos6502/_strlen.s	(working copy)
+@@ -42,7 +42,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ _strlen:
+ 	sta	*_src+0
+Index: sdcc/device/lib/mos6502/abs.s
+===================================================================
+--- sdcc/device/lib/mos6502/abs.s	(revision 14868)
++++ sdcc/device/lib/mos6502/abs.s	(working copy)
+@@ -38,7 +38,7 @@
+ ; code
+ ;--------------------------------------------------------
+ 
+-	.area CODE
++	.area _CODE
+ _abs:
+ 	cpx #0x00
+ 	bpl skip
+Index: sdcc/device/lib/mos6502/crt0.s
+===================================================================
+--- sdcc/device/lib/mos6502/crt0.s	(revision 14868)
++++ sdcc/device/lib/mos6502/crt0.s	(working copy)
+@@ -30,19 +30,18 @@
+ 	.module crt0
+ 
+ 	;; Ordering of segments for the linker.
+-	.area ZP      (PAG)
++	.area _ZP     (PAG)
+ 	.area OSEG    (PAG, OVR)
+ 
+ 	.area _DATA
+-	.area DATA
+-	.area BSS
++	.area _BSS
+ 
++;	.area _CODE
++	.area _GSINIT
++	.area _GSFINAL
+ 	.area _CODE
+-	.area GSINIT
+-	.area GSFINAL
+-	.area CODE
+-	.area RODATA
+-	.area XINIT
++	.area _RODATA
++	.area _XINIT
+ 
+ 	;; Reset/interrupt vectors
+ 	.area CODEIVT (ABS)
+@@ -51,7 +50,7 @@
+ 	.dw	__sdcc_gs_init_startup ; RESET
+ 	.dw	__sdcc_gs_init_startup ; IRQ/BRK
+ 
+-	.area GSINIT
++	.area _GSINIT
+ __sdcc_gs_init_startup:
+ 	ldx	#0xff
+ 	txs
+@@ -68,8 +67,8 @@
+ __sdcc_init_data:
+ ;; clear ZP
+ 	lda	#0x00
+-	ldx	#<s_ZP
+-	ldy	#<l_ZP
++	ldx	#<s__ZP
++	ldy	#<l__ZP
+ 	beq	00101$
+ 00100$:
+ 	sta	*0,X
+@@ -79,30 +78,30 @@
+ 00101$:
+ 
+ ;; initialize DATA
+-	lda	#>l_XINIT
++	lda	#>l__XINIT
+ 	sta	*___memcpy_PARM_3+1
+-	lda	#<l_XINIT
++	lda	#<l__XINIT
+ 	sta	*___memcpy_PARM_3
+-	lda	#>s_XINIT
++	lda	#>s__XINIT
+ 	sta	*___memcpy_PARM_2+1
+-	lda	#<s_XINIT
++	lda	#<s__XINIT
+ 	sta	*___memcpy_PARM_2
+-	lda	#<s_DATA
+-	ldx	#>s_DATA
++	lda	#<s__DATA
++	ldx	#>s__DATA
+ 	jsr	___memcpy
+ 
+ ;; clear BSS
+-	lda	#>l_BSS
++	lda	#>l__BSS
+ 	sta	*_memset_PARM_3+1
+-	lda	#<l_BSS
++	lda	#<l__BSS
+ 	sta	*_memset_PARM_3
+ 	lda	#0x00
+ 	sta	*_memset_PARM_2
+-	lda	#<s_BSS
+-	ldx	#>s_BSS
++	lda	#<s__BSS
++	ldx	#>s__BSS
+ 	jsr	_memset
+ 
+-	.area GSFINAL
++	.area _GSFINAL
+ __sdcc_program_startup:
+ 	jsr	_main
+ 	jmp	.
+Index: sdcc/device/lib/mos6502/memcpy.s
+===================================================================
+--- sdcc/device/lib/mos6502/memcpy.s	(revision 14868)
++++ sdcc/device/lib/mos6502/memcpy.s	(working copy)
+@@ -62,7 +62,7 @@
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-	.area CODE
++	.area _CODE
+ 
+ _memcpy:
+ ___memcpy:
+Index: sdcc/device/lib/mos6502-stack-auto/_setjmp.c
+===================================================================
+--- sdcc/device/lib/mos6502-stack-auto/_setjmp.c	(revision 14868)
++++ sdcc/device/lib/mos6502-stack-auto/_setjmp.c	(working copy)
+@@ -37,13 +37,13 @@
+ ;--------------------------------------------------------
+ ; extended address mode data
+ ;--------------------------------------------------------
+-        .area BSS
++        .area _BSS
+ _longjmp_PARM_2:
+         .ds 2
+ ;--------------------------------------------------------
+ ; code
+ ;--------------------------------------------------------
+-        .area CODE
++        .area _CODE
+ ;------------------------------------------------------------
+ ;Allocation info for local variables in function '__setjmp'
+ ;------------------------------------------------------------
+Index: sdcc/device/lib/mos6502-stack-auto/crt0.s
+===================================================================
+--- sdcc/device/lib/mos6502-stack-auto/crt0.s	(revision 14868)
++++ sdcc/device/lib/mos6502-stack-auto/crt0.s	(working copy)
+@@ -30,19 +30,18 @@
+ 	.module crt0
+ 
+ 	;; Ordering of segments for the linker.
+-	.area ZP      (PAG)
++	.area _ZP     (PAG)
+ 	.area OSEG    (PAG, OVR)
+ 
+ 	.area _DATA
+-	.area DATA
+-	.area BSS
++	.area _BSS
+ 
++;	.area _CODE
++	.area _GSINIT
++	.area _GSFINAL
+ 	.area _CODE
+-	.area GSINIT
+-	.area GSFINAL
+-	.area CODE
+-	.area RODATA
+-	.area XINIT
++	.area _RODATA
++	.area _XINIT
+ 
+ 	;; Reset/interrupt vectors
+ 	.area CODEIVT (ABS)
+@@ -51,7 +50,7 @@
+ 	.dw	__sdcc_gs_init_startup ; RESET
+ 	.dw	__sdcc_gs_init_startup ; IRQ/BRK
+ 
+-	.area GSINIT
++	.area _GSINIT
+ __sdcc_gs_init_startup:
+ 	ldx	#0xff
+ 	txs
+@@ -68,8 +67,8 @@
+ __sdcc_init_data:
+ ;; clear ZP
+ 	lda	#0x00
+-	ldx	#<s_ZP
+-	ldy	#<l_ZP
++	ldx	#<s__ZP
++	ldy	#<l__ZP
+ 	beq	00101$
+ 00100$:
+ 	sta	*0,X
+@@ -79,17 +78,17 @@
+ 00101$:
+ 
+ ;; initialize DATA
+-	lda	#>l_XINIT
++	lda	#>l__XINIT
+ 	pha
+-	lda	#<l_XINIT
++	lda	#<l__XINIT
+ 	pha
+ 
+-	lda	#>s_XINIT
++	lda	#>s__XINIT
+ 	pha
+-	lda	#<s_XINIT
++	lda	#<s__XINIT
+ 	pha
+-	lda	#<s_DATA
+-	ldx	#>s_DATA
++	lda	#<s__DATA
++	ldx	#>s__DATA
+ 	jsr	___memcpy
+ 	pla
+ 	pla
+@@ -97,17 +96,17 @@
+ 	pla
+ 
+ ;; clear BSS
+-	lda	#>l_BSS
++	lda	#>l__BSS
+ 	pha
+-	lda	#<l_BSS
++	lda	#<l__BSS
+ 	pha
+ 	lda	#0x00
+ 	pha
+-	lda	#<s_BSS
+-	ldx	#>s_BSS
++	lda	#<s__BSS
++	ldx	#>s__BSS
+ 	jsr	_memset
+ 
+-	.area GSFINAL
++	.area _GSFINAL
+ __sdcc_program_startup:
+ 	jsr	_main
+ 	jmp	.
+Index: sdcc/src/SDCCasm.c
+===================================================================
+--- sdcc/src/SDCCasm.c	(revision 14868)
++++ sdcc/src/SDCCasm.c	(working copy)
+@@ -408,10 +408,10 @@
+   {"immed", "#"},
+   {"zero", "#0x00"},
+   {"one", "#0x01"},
+-  {"area", ".area %s"},
+-  {"areacode", ".area %s"},
+-  {"areadata", ".area %s"},
+-  {"areahome", ".area %s"},
++  {"area", ".area _%s"},
++  {"areacode", ".area _%s"},
++  {"areadata", ".area _%s"},
++  {"areahome", ".area _%s"},
+   {"ascii", ".ascii \"%s\""},
+   {"ds", ".ds %d"},
+   {"db", ".db"},
+Index: sdcc/src/mos6502/main.c
+===================================================================
+--- sdcc/src/mos6502/main.c	(revision 15224)
++++ sdcc/src/mos6502/main.c	(working copy)
+@@ -221,10 +221,11 @@
+   tfprintf (of, "\t!area\n", STATIC_NAME);
+   tfprintf (of, "\t!area\n", "GSFINAL");
+   tfprintf (of, "\t!area\n", CODE_NAME);
+-  tfprintf (of, "\t!area\n", CONST_NAME);
++  if(CONST_NAME != NULL)
++      tfprintf (of, "\t!area\n", CONST_NAME);
+   tfprintf (of, "\t!area\n", XINIT_NAME);
+ 
+-  tfprintf (of, "\t!area\n", "_DATA");
++  tfprintf (of, "\t!area\n", "DATA");
+   tfprintf (of, "\t!area\n", XIDATA_NAME);
+   //  if(options.xdata_overlay)
+   //      tfprintf (of, "\t!area    (OVR)\n", OVERLAY_NAME);
+@@ -747,10 +748,10 @@
+       "GSINIT",                 /* static initialization */
+       "OSEG    (PAG, OVR)",     /* overlay */
+       "GSFINAL",                /* gsfinal */
+-      "_CODE",                  /* home */
++      "HOME",                   /* home */
+       "DATA",                   /* initialized xdata */
+       "XINIT",                  /* a code copy of DATA */
+-      "RODATA",                 /* const_name */
++      NULL,                     /* const_name */
+       "CABS    (ABS)",          /* cabs_name - const absolute data */
+       "DABS    (ABS)",          /* xabs_name - absolute xdata */
+       NULL,                     /* iabs_name */
+@@ -916,10 +917,10 @@
+       "GSINIT",                 // static initialization
+       "OSEG    (PAG, OVR)",     // overlay
+       "GSFINAL",                // gsfinal
+-      "_CODE",                  // home
++      "HOME",                   // home
+       "DATA",                   // initialized xdata
+       "XINIT",                  // a code copy of DATA
+-      "RODATA",                 // const_name - const data (code or not)
++      NULL    ,                 // const_name - const data (code or not)
+       "CABS    (ABS)",          // cabs_name - const absolute data (code or not)
+       "DABS    (ABS)",          // xabs_name - absolute xdata
+       NULL,                     // iabs_name - absolute data
+

--- a/Patches/0200_at_15224_sdcc_mos6502_bank_support.patch
+++ b/Patches/0200_at_15224_sdcc_mos6502_bank_support.patch
@@ -1,0 +1,405 @@
+diff -rupN ../sdcc-code-14868_with_mos6502_underscored_segments/sdcc/src/mos6502/gen.c ./sdcc/src/mos6502/gen.c
+--- ../sdcc-code-14868_with_mos6502_underscored_segments/sdcc/src/mos6502/gen.c	2024-05-28 17:29:28.585759700 +0100
++++ ./sdcc/src/mos6502/gen.c	2024-05-28 20:11:41.475759700 +0100
+@@ -80,6 +80,7 @@ static struct
+   int lastflag;
+   struct attr_t tempAttr[NUM_TEMP_REGS];
+   struct attr_t DPTRAttr[2];
++  bool in_home;
+ } _G;
+ 
+ extern int m6502_ptrRegReq;
+@@ -180,6 +181,33 @@ safeLabelNum(symbol * a)
+   return 0;
+ }
+ 
++/* Duplicated from z80/gen.c */
++/* This is quite unfortunate */
++static void
++setArea (int inHome)
++{
++  /*
++     static int lastArea = 0;
++
++     if (_G.in_home != inHome) {
++     if (inHome) {
++     const char *sz = port->mem.code_name;
++     port->mem.code_name = "HOME";
++     emit2("!area", CODE_NAME);
++     port->mem.code_name = sz;
++     }
++     else
++     emit2("!area", CODE_NAME); */
++  _G.in_home = inHome;
++  //    }
++}
++
++static bool
++isInHome (void)
++{
++  return _G.in_home;
++}
++
+ /**************************************************************************
+  * Returns the cycle count for the instruction
+  *
+@@ -4575,6 +4603,69 @@ genSend (set *sendSet)
+     }
+ }
+ 
++// From z80/gen.c
++static void
++_tidyUp (char *buf)
++{
++  /* Clean up the line so that it is 'prettier' */
++  /* If it is a label - can't do anything */
++  if (!strchr (buf, ':'))
++    {
++      /* Change the first (and probably only) ' ' to a tab so
++         everything lines up.
++       */
++      while (*buf)
++        {
++          if (*buf == ' ')
++            {
++              *buf = '\t';
++              break;
++            }
++          buf++;
++        }
++    }
++}
++
++static void
++_vemit2 (const char *szFormat, va_list ap)
++{
++  struct dbuf_s dbuf;
++  char *buffer, *p, *nextp;
++
++  dbuf_init (&dbuf, INITIAL_INLINEASM);
++
++  dbuf_tvprintf (&dbuf, szFormat, ap);
++
++  buffer = p = dbuf_detach_c_str (&dbuf);
++
++  _tidyUp (p);
++
++  /* Decompose multiline macros */
++  while ((nextp = strchr (p, '\n')))
++    {
++      *nextp = '\0';
++      emit_raw (p);
++      p = nextp + 1;
++    }
++
++  emit_raw (p);
++
++  dbuf_free (buffer);
++}
++
++static void
++emit2 (const char *szFormat, ...)
++{
++  if (!regalloc_dry_run)
++    {
++      va_list ap;
++
++      va_start (ap, szFormat);
++      _vemit2 (szFormat, ap);
++      va_end (ap);
++    }
++}
++
+ /**************************************************************************
+  * genCall - generates a call statement
+  *************************************************************************/
+@@ -4616,8 +4707,18 @@ genCall (iCode * ic)
+   } else {
+     bool jump = (!ic->parmBytes && IFFUNC_ISNORETURN (OP_SYMBOL (left)->type));
+ 
+-    emit6502op (jump ? "jmp" : "jsr", "%s", (OP_SYMBOL (left)->rname[0] ?
+-                                             OP_SYMBOL (left)->rname : OP_SYMBOL (left)->name));
++      if (IFFUNC_ISBANKEDCALL (dtype) && !jump)
++        {
++          char *name = OP_SYMBOL (IC_LEFT (ic))->rname[0] ? OP_SYMBOL (IC_LEFT (ic))->rname : OP_SYMBOL (IC_LEFT (ic))->name;
++          emit2 ("jsr ___sdcc_bcall");
++          emit2 ("!db !bankimmeds", name);
++          emitcode (".dw ", "%s-1", name);
++        }
++      else
++        {
++          emit6502op (jump ? "jmp" : "jsr", "%s", (OP_SYMBOL (left)->rname[0] ?
++                                  OP_SYMBOL (left)->rname : OP_SYMBOL (left)->name));
++        }
+   }
+ 
+   m6502_dirtyReg (m6502_reg_a);
+@@ -4802,6 +4903,8 @@ static void genFunction (iCode * ic)
+   int stackAdjust = sym->stack;
+   //  int accIsFree = sym->recvSize == 0;
+ 
++  setArea (IFFUNC_NONBANKED (sym->type));
++
+   /* create the function header */
+   emitComment (ALWAYS, "-----------------------------------------");
+   emitComment (ALWAYS, " function %s", sym->name);
+@@ -4809,6 +4912,20 @@ static void genFunction (iCode * ic)
+   emitComment (ALWAYS, m6502_assignment_optimal ? "Register assignment is optimal." : "Register assignment might be sub-optimal.");
+   emitComment (ALWAYS, "Stack space usage: %d bytes.", sym->stack);
+ 
++  if (IFFUNC_BANKED (sym->type))
++    {
++      int bank_number = 0;
++      for (int i  = strlen (options.code_seg)-1; i >= 0; i--)
++        {
++          if (!isdigit (options.code_seg[i]) && options.code_seg[i+1] != '\0')
++            {
++              bank_number = atoi (&options.code_seg[i+1]);
++              break;
++            }
++        }
++      emit2("!bequ", sym->rname, bank_number);
++    }
++
+   emitcode ("", "%s:", sym->rname);
+   genLine.lineCurr->isLabel = 1;
+   ftype = operandType (IC_LEFT (ic));
+@@ -10786,6 +10903,11 @@ genm6502Code (iCode *lic)
+   if (!options.nopeep)
+     peepHole (&genLine.lineHead);
+ 
++  /* Duplicated from z80/gen.c */
++  /* This is unfortunate */
++  if (isInHome () && codeOutBuf == &code->oBuf)
++    codeOutBuf = &home->oBuf;
++
+   /* now do the actual printing */
+   printLine (genLine.lineHead, codeOutBuf);
+ 
+Index: sdcc/src/mos6502/main.c
+===================================================================
+--- sdcc/src/mos6502/main.c	(revision 15224)
++++ sdcc/src/mos6502/main.c	(working copy)
+@@ -30,6 +30,7 @@
+ #include "m6502.h"
+ #include "peep.h"
+ 
++#define OPTION_BO               "-bo"
+ #define OPTION_SMALL_MODEL      "--model-small"
+ #define OPTION_LARGE_MODEL      "--model-large"
+ //#define OPTION_XDATA_OVR        "--xdata-overlay"
+@@ -83,6 +84,8 @@
+   "at",
+   "critical",
+   "interrupt",
++  "nonbanked",
++  "banked",
+   "naked",
+   "reentrant",
+   "code",
+@@ -154,10 +157,146 @@
+   return 1+_G.regparam.n-size;
+ }
+ 
++enum
++{
++  P_BANK = 1,
++  P_PORTMODE,
++  P_CODESEG,
++  P_CONSTSEG,
++};
++
++static int
++do_pragma (int id, const char *name, const char *cp)
++{
++  struct pragma_token_s token;
++  int err = 0;
++  int processed = 1;
++
++  init_pragma_token (&token);
++
++  switch (id)
++    {
++    case P_BANK:
++      {
++        struct dbuf_s buffer;
++
++        dbuf_init (&buffer, 128);
++
++        cp = get_pragma_token (cp, &token);
++
++        switch (token.type)
++          {
++          case TOKEN_EOL:
++            err = 1;
++            break;
++
++          case TOKEN_INT:
++            dbuf_printf (&buffer, "CODE_%d", token.val.int_val);
++            break;
++
++          default:
++            {
++              const char *str = get_pragma_string (&token);
++
++              dbuf_append_str (&buffer, (0 == strcmp ("BASE", str)) ? "HOME" : str);
++            }
++            break;
++          }
++
++        cp = get_pragma_token (cp, &token);
++        if (TOKEN_EOL != token.type)
++          {
++            err = 1;
++            break;
++          }
++
++        dbuf_c_str (&buffer);
++        options.code_seg = (char *) dbuf_detach (&buffer);
++      }
++      break;
++
++    case P_CODESEG:
++    case P_CONSTSEG:
++      {
++        char *segname;
++
++        cp = get_pragma_token (cp, &token);
++        if (token.type == TOKEN_EOL)
++          {
++            err = 1;
++            break;
++          }
++
++        segname = Safe_strdup (get_pragma_string (&token));
++
++        cp = get_pragma_token (cp, &token);
++        if (token.type != TOKEN_EOL)
++          {
++            Safe_free (segname);
++            err = 1;
++            break;
++          }
++
++        if (id == P_CODESEG)
++          {
++            if (options.code_seg)
++              Safe_free (options.code_seg);
++            options.code_seg = segname;
++          }
++        else
++          {
++            if (options.const_seg)
++              Safe_free (options.const_seg);
++            options.const_seg = segname;
++          }
++      }
++      break;
++
++    default:
++      processed = 0;
++      break;
++    }
++
++  get_pragma_token (cp, &token);
++
++  if (1 == err)
++    werror (W_BAD_PRAGMA_ARGUMENTS, name);
++
++  free_pragma_token (&token);
++  return processed;
++}
++
++static struct pragma_s pragma_tbl[] = {
++  {"bank", P_BANK, 0, do_pragma},
++  {"codeseg", P_CODESEG, 0, do_pragma},
++  {"constseg", P_CONSTSEG, 0, do_pragma},
++  {NULL, 0, 0, NULL},
++};
++
++static int
++_process_pragma (const char *s)
++{
++  return process_pragma_tbl (pragma_tbl, s);
++}
++
+ static bool
+ m6502_parseOptions (int *pargc, char **argv, int *i)
+ {
+-  return false;
++    if (argv[*i][0] == '-')
++    {
++        if (!strncmp (argv[*i], OPTION_BO, sizeof (OPTION_BO) - 1))
++        {
++            /* ROM bank */
++            int bank = getIntArg (OPTION_BO, argv, i, *pargc);
++            struct dbuf_s buffer;
++            dbuf_init (&buffer, 16);
++            dbuf_printf (&buffer, "CODE_%u", bank);
++            dbuf_c_str (&buffer);
++            options.code_seg = (char *) dbuf_detach (&buffer);
++            return true;
++        }
++    }
++    return false;
+ }
+ 
+ static void
+@@ -766,11 +905,11 @@
+     0,                          /* default ABI revision */
+     {                           /* stack information */
+       -1,                       /* stack grows down */
+-      0,                        /* bank_overhead (switch between register banks) */
++      3,                        /* bank_overhead (switch between register banks) */
+       6,                        /* isr overhead */
+       2,                        /* call overhead */
+       0,                        /* reent_overhead */
+-      0,                        /* banked_overhead (switch between code banks) */
++      3,                        /* banked_overhead (switch between code banks) */
+       1,                        /* sp points to next free stack location */
+     },
+     {
+@@ -818,7 +957,7 @@
+     0,                          /* genInitStartup */
+     m6502_reset_regparm,
+     m6502_regparm,
+-    NULL,                       /* process_pragma */
++    _process_pragma,            /* process_pragma */
+     NULL,                       /* getMangledFunctionName */
+     _hasNativeMulFor,           /* hasNativeMulFor */
+     hasExtBitOp,                /* hasExtBitOp */
+@@ -935,11 +1074,11 @@
+     0,                          // ABI revision
+     {
+       -1,                       /* direction (-1 = stack grows down) */
+-      0,                        /* bank_overhead (switch between register banks) */
++      3,                        /* bank_overhead (switch between register banks) */
+       4,                        /* isr_overhead */
+       2,                        /* call_overhead */
+       0,                        /* reent_overhead */
+-      0,                        /* banked_overhead (switch between code banks) */
++      3,                        /* banked_overhead (switch between code banks) */
+       1                         /* sp is offset by 1 from last item pushed */
+     },
+     {
+@@ -987,7 +1126,7 @@
+     0,                          /* genInitStartup */
+     m6502_reset_regparm,
+     m6502_regparm,
+-    0,                          /* process_pragma */
++    _process_pragma,            /* process_pragma */
+     NULL,                       /* getMangledFunctionName */
+     _hasNativeMulFor,           /* hasNativeMulFor */
+     hasExtBitOp,                /* hasExtBitOp */
+diff -rupN ../sdcc-code-14868_with_mos6502_underscored_segments/sdcc/src/SDCCglue.c ./sdcc/src/SDCCglue.c
+--- ../sdcc-code-14868_with_mos6502_underscored_segments/sdcc/src/SDCCglue.c	2024-05-28 17:29:28.755759700 +0100
++++ ./sdcc/src/SDCCglue.c	2024-05-28 20:24:49.135759700 +0100
+@@ -2164,7 +2164,7 @@ printPublics (FILE * afile)
+ 
+   for (sym = setFirstItem (publics); sym; sym = setNextItem (publics))
+     {
+-      if (TARGET_Z80_LIKE && IFFUNC_BANKED(sym->type))
++      if (IFFUNC_BANKED(sym->type))
+         {
+           /* TODO: use template for bank symbol generation */
+           sprintf (buffer, "b%s", sym->rname);

--- a/Patches/0300_at_15224_m6502_no_overlay_locals.patch
+++ b/Patches/0300_at_15224_m6502_no_overlay_locals.patch
@@ -1,0 +1,96 @@
+Index: sdcc/src/SDCC.lex
+===================================================================
+--- sdcc/src/SDCC.lex	(revision 15224)
++++ sdcc/src/SDCC.lex	(working copy)
+@@ -237,6 +237,7 @@
+ "__naked"               { count (); TKEYWORD (NAKED); }
+ "_JavaNative"           { count (); TKEYWORD (JAVANATIVE); }
+ "__overlay"             { count (); TKEYWORD (OVERLAY); }
++"__no_overlay_locals"   { count (); TKEYWORD (NO_OVERLAY_LOCALS); }
+ "__smallc"              { count (); TKEYWORD (SMALLC); }
+ "__raisonance"          { count (); TKEYWORD (RAISONANCE); }
+ "__iar"                 { count (); TKEYWORD (IAR); }
+Index: sdcc/src/SDCC.y
+===================================================================
+--- sdcc/src/SDCC.y	(revision 15224)
++++ sdcc/src/SDCC.y	(working copy)
+@@ -106,7 +106,7 @@
+ %token COMPLEX IMAGINARY
+ %token STRUCT UNION ENUM RANGE SD_FAR
+ %token CASE DEFAULT IF ELSE SWITCH WHILE DO FOR GOTO CONTINUE BREAK RETURN
+-%token NAKED JAVANATIVE OVERLAY TRAP
++%token NAKED JAVANATIVE OVERLAY NO_OVERLAY_LOCALS TRAP
+ %token <yystr> STRING_LITERAL INLINEASM FUNC
+ %token IFX ADDRESS_OF GET_VALUE_AT_ADDRESS SET_VALUE_AT_ADDRESS SPIL UNSPIL GETABIT GETBYTE GETWORD
+ %token BITWISEAND UNARYMINUS IPUSH IPUSH_VALUE_AT_ADDRESS IPOP PCALL ENDFUNCTION JUMPTABLE
+@@ -2414,6 +2414,9 @@
+    |  OVERLAY        {  $$ = newLink (SPECIFIER);
+                         FUNC_ISOVERLAY($$)=1;
+                      }
++   |  NO_OVERLAY_LOCALS {  $$ = newLink (SPECIFIER);
++                        FUNC_ISNO_OVERLAY_LOCALS($$)=1;
++                     }
+    |  NONBANKED      {$$ = newLink (SPECIFIER);
+                         FUNC_NONBANKED($$) = 1;
+                         if (FUNC_BANKED($$)) {
+Index: sdcc/src/SDCCmem.c
+===================================================================
+--- sdcc/src/SDCCmem.c	(revision 15224)
++++ sdcc/src/SDCCmem.c	(working copy)
+@@ -1311,8 +1311,9 @@
+               if (ic->op == CALL)
+                 {
+                   sym_link *ftype = operandType(IC_LEFT(ic));
+-                  /* builtins only can use overlays */
+-                  if (!IFFUNC_ISBUILTIN(ftype)) return FALSE;
++                  /* builtins can use overlays. */
++                  /* and NO_OVERLAY_LOCALS functions can safely be ignored (they use their own memory) */
++                  if (!(IFFUNC_ISBUILTIN(ftype) || IFFUNC_ISNO_OVERLAY_LOCALS(ftype))) return FALSE;
+                 }
+               else if (ic->op == PCALL)
+                 {
+Index: sdcc/src/SDCCsymt.h
+===================================================================
+--- sdcc/src/SDCCsymt.h	(revision 15224)
++++ sdcc/src/SDCCsymt.h	(working copy)
+@@ -275,6 +275,7 @@
+     unsigned builtin;               /* is a builtin function                */
+     unsigned javaNative;            /* is a JavaNative Function (TININative ONLY) */
+     unsigned overlay;               /* force parameters & locals into overlay segment */
++    unsigned no_overlay_locals;     /* Function does NOT use compiler's overlay segment for local variables */
+     unsigned hasStackParms;         /* function has parameters on stack     */
+     bool preserved_regs[9];         /* Registers preserved by the function - may be an underestimate */
+     unsigned char z88dk_shortcall_rst;  /* Rst for a short call */
+@@ -456,6 +457,8 @@
+ #define IFFUNC_ISJAVANATIVE(x) (IS_FUNC(x) && FUNC_ISJAVANATIVE(x))
+ #define FUNC_ISOVERLAY(x) (x->funcAttrs.overlay)
+ #define IFFUNC_ISOVERLAY(x) (IS_FUNC(x) && FUNC_ISOVERLAY(x))
++#define FUNC_ISNO_OVERLAY_LOCALS(x) (x->funcAttrs.no_overlay_locals)
++#define IFFUNC_ISNO_OVERLAY_LOCALS(x) (IS_FUNC(x) && FUNC_ISNO_OVERLAY_LOCALS(x))
+ #define FUNC_ISSMALLC(x) (x->funcAttrs.smallc)
+ #define IFFUNC_ISSMALLC(x) (IS_FUNC(x) && FUNC_ISSMALLC(x))
+ #define FUNC_ISRAISONANCE(x) (x->funcAttrs.raisonance)
+Index: sdcc/src/mos6502/main.c
+===================================================================
+--- sdcc/src/mos6502/main.c	(revision 15224)
++++ sdcc/src/mos6502/main.c	(working copy)
+@@ -92,6 +92,7 @@
+   "xdata",
+   "far",
+   //  "overlay",
++  "no_overlay_locals",
+   //  "using",
+   //  "generic",
+   NULL
+Index: sdcc/src/reswords.gperf
+===================================================================
+--- sdcc/src/reswords.gperf	(revision 15224)
++++ sdcc/src/reswords.gperf	(working copy)
+@@ -58,6 +58,7 @@
+ near,		DATA,		1
+ pdata,		PDATA,		1
+ reentrant,	REENTRANT,	1
++no_overlay_locals,	NO_OVERLAY_LOCALS,	1
+ sfr,		SFR,		1
+ sbit,		SBIT,		1
+ sram,		XDATA,		1

--- a/Patches/0400_sdld_virtual_address_translation.patch
+++ b/Patches/0400_sdld_virtual_address_translation.patch
@@ -1,0 +1,268 @@
+Index: sdcc/sdas/linksrc/aslink.h
+===================================================================
+--- sdcc/sdas/linksrc/aslink.h	(revision 14868)
++++ sdcc/sdas/linksrc/aslink.h	(working copy)
+@@ -381,7 +381,17 @@
+                                  */
+ /* end sdld specific */
+ 
++/* Options for platform specific virtual address translation
++*
++*
++*/
++#define PLATFORM_NONE         0      /* Default address handling */
++#define PLATFORM_SMS          1      /* SMS/GG specific virtual address handling */
++#define PLATFORM_NES          2      /* NES/Famicom specific virtual address handling */
+ 
++#define PLATFORM_SMS_STR      "sms"
++#define PLATFORM_NES_STR      "nes"
++
+ /*
+  *	The "A4_" area constants define values used in
+  *	generating the assembler area output data.
+@@ -1040,6 +1050,8 @@
+                                  */
+ extern  int     uflag;          /*      Listing relocation flag
+                                  */
++extern  int     platform;       /*      Select platform specific virtual address translation
++                                 */
+ extern  int     wflag;          /*      Enable wide format listing
+                                  */
+ extern  int     zflag;          /*      Disable symbol case sensitivity
+@@ -1161,6 +1173,7 @@
+ extern  VOID            bassav(void);
+ extern  int             fndidx(char *str);
+ extern  int             fndext(char *str);
++extern  VOID            platset(void);
+ extern  VOID            gblsav(void);
+ extern  int             intsiz(void);
+ extern  VOID            iramsav(void);
+Index: sdcc/sdas/linksrc/lkarea.c
+===================================================================
+--- sdcc/sdas/linksrc/lkarea.c	(revision 14868)
++++ sdcc/sdas/linksrc/lkarea.c	(working copy)
+@@ -321,6 +321,8 @@
+  *                                      area structure
+  *              area    *areap          The pointer to the first
+  *                                      area structure of a linked list
++ *              int     platform        selects platform specific
++ *                                      virtual address translation
+  *
+  *      functions called:
+  *              int     fprintf()       c_library
+@@ -336,7 +338,7 @@
+  */
+ 
+ /* sdld6808 specific */
+-unsigned long codemap6808[2048];
++unsigned long codemap6808[524288];
+ /* end sdld6808 specific */
+ /* sdld specific */
+ VOID lnksect(struct area *tap);
+@@ -424,6 +426,30 @@
+                                 ap->a_addr = (atoi(ap->a_id+6) << 16) + 0xA000;
+                         }
+                 }
++                // Z80 sms/gg virtual address / mapper handling
++                if (TARGET_IS_Z80 && (platform == PLATFORM_SMS) && ap->a_addr == 0) {
++                        // Standard sega sms/gg mapper used by most
++                        if (!strncmp(ap->a_id, "_CODE_", 6) && atoi(ap->a_id+6)!=0) {
++                                ap->a_addr = (atoi(ap->a_id+6) << 16) + 0x4000;
++                        }
++                        if (!strncmp(ap->a_id, "_LIT_", 5) && atoi(ap->a_id+5)!=0) {
++                                ap->a_addr = (atoi(ap->a_id+5) << 16) + 0x8000;
++                        }
++                        if (!strncmp(ap->a_id, "_DATA_", 6)) {
++                                // set sane default values for ram banking
++                                ap->a_addr = (atoi(ap->a_id+6) << 16) + 0x8000;
++                        }
++                }
++                if((platform == PLATFORM_NES) && ap->a_addr == 0) {
++                        if(!strncmp(ap->a_id, "_CODE_", 6)) {
++                                // set sane default values for rom banking
++                                // 0x8000 is correct for most NES mappers with 
++                                // 16kB switching, such as UNROM.
++                                ap->a_addr = (atoi(ap->a_id+6) << 16) + 0x8000;
++                                // Set this to prevent further odd & unexpected relocation further down
++                                ap->a_bset = 1;
++                        }
++                }
+                 if (ap->a_flag & A3_ABS) {
+                         /*
+                          * Absolute sections
+Index: sdcc/sdas/linksrc/lkdata.c
+===================================================================
+--- sdcc/sdas/linksrc/lkdata.c	(revision 14868)
++++ sdcc/sdas/linksrc/lkdata.c	(working copy)
+@@ -84,6 +84,8 @@
+                          */
+ int     uflag;          /*      Listing relocation flag
+                          */
++int     platform;       /*      Select platform specific virtual address translation
++                         */
+ int     wflag;          /*      Enable wide format listing
+                          */
+ int     zflag;          /*      Disable symbol case sensitivity
+@@ -148,6 +150,8 @@
+ /* sdld specific */
+ char    *optsdcc;
+ char    *optsdcc_module;
++int     platform = PLATFORM_NONE; /* Select platform specific virtual address translation
++                         */
+ int     sflag;          /*      JCF: Memory usage output flag
+                          */
+ int     stacksize=0;    /*      JCF: Stack size
+Index: sdcc/sdas/linksrc/lkmain.c
+===================================================================
+--- sdcc/sdas/linksrc/lkmain.c	(revision 14868)
++++ sdcc/sdas/linksrc/lkmain.c	(working copy)
+@@ -226,6 +226,10 @@
+                                 /*
+                                  * Options with arguments
+                                  */
++                                case 'a':
++                                case 'A':
++                                        pflag = 0;
++
+                                 case 'b':
+                                 case 'B':
+ 
+@@ -904,6 +908,7 @@
+  *              int     oflag           Output file type flag
+  *              int     objflg          Linked file/library output object flag
+  *              int     pflag           print linker command file flag
++ *              int     platform        Selects platform specific virtual address translation
+  *              FILE *  stderr          c_library
+  *              int     uflag           Relocated listing flag
+  *              int     xflag           Map file radix type flag
+@@ -913,6 +918,7 @@
+  *      Functions called:
+  *              VOID    addlib()        lklibr.c
+  *              VOID    addpath()       lklibr.c
++ *              VOID    platset()       lkmain.c
+  *              VOID    bassav()        lkmain.c
+  *              VOID    doparse()       lkmain.c
+  *              int     fprintf()       c_library
+@@ -946,6 +952,13 @@
+                         while (ctype[c=get()] & LETTER) {
+                                 switch(c) {
+ 
++                                case 'a':
++                                case 'A':
++                                        if (is_sdld()) {
++                                            platset();
++                                        }
++                                        return(0);
++
+                                 case 'C':
+                                         if (is_sdld() && !(TARGET_IS_Z80 || TARGET_IS_GB)) {
+                                                 codesav();
+@@ -1229,6 +1242,47 @@
+         startp->f_type = 0;
+ }
+ 
++/*)Function     VOID    platset()
++ *
++ *      The function platset() sets variable which stores platform
++ *      specific virtual address translation.
++ *
++ *      local variables:
++ *              none
++ *
++ *      global variables:
++ *              int     platform        selects platform specific
++ *                                      virtual address translation
++ *              char    *ip             pointer into the REL file
++ *                                      text line in ib[]
++ *
++ *       functions called:
++ *              int     fprintf()       c_library
++ *              int     getnb()         lklex.c
++ *              int     strcmp()        c_library
++ *              VOID    unget()         lklex.c
++ *
++ *      side effects:
++ *              The basep structure is created.
++ */
++
++VOID
++platset()
++{
++        unget(getnb());
++        if (strcmp(ip, PLATFORM_SMS_STR) == 0) {
++                platform = PLATFORM_SMS;
++                return;
++        }
++        else if (strcmp(ip, PLATFORM_NES_STR) == 0) {
++                platform = PLATFORM_NES;
++                return;
++        }
++        fprintf(stderr,
++        "No matching platform found for: %s\n", ip);
++}
++
++
+ /*)Function     VOID    bassav()
+  *
+  *      The function bassav() creates a linked structure containing
+@@ -1698,6 +1752,7 @@
+         "Relocation:",
+         "  -b   area base address = expression",
+         "  -g   global symbol = expression",
++        "  -a   (platform) Select platform specific virtual address translation",
+         "Map format:",
+         "  -m   Map output generated as (out)file[.map]",
+         "  -w   Wide listing format for map file",
+@@ -1741,6 +1796,7 @@
+         "Relocation:",
+         "  -b   area base address = expression",
+         "  -g   global symbol = expression",
++        "  -a   (platform) Select platform specific virtual address translation",
+         "Map format:",
+         "  -m   Map output generated as (out)file[.map]",
+         "  -w   Wide listing format for map file",
+Index: sdcc/sdas/linksrc/lkout.c
+===================================================================
+--- sdcc/sdas/linksrc/lkout.c	(revision 14868)
++++ sdcc/sdas/linksrc/lkout.c	(working copy)
+@@ -364,6 +364,8 @@
+  *      global variables:
+  *              int     a_bytes         T Line Address Bytes
+  *              FILE *  ofp             output file handle
++ *              int     platform        selects platform specific
++ *                                      virtual address translation
+  *              int     rtaflg          first output flag
+  *              char    rtbuf[]         output buffer
+  *              a_uint  rtadr0          address temporary
+@@ -401,6 +403,31 @@
+                         rrtadr0 = (rrtadr0>>16) * 0x4000 + (rrtadr0&0xffff) - 0x4000;
+         }
+ 
++        // translate virtual addresses for sms/gg
++        if(platform == PLATFORM_SMS){
++                if(rrtadr0 >= 0x10000)
++                        rrtadr0 = ((rrtadr0 >> 16) * 0x4000) + (rrtadr0 & 0x3FFF);
++        }
++
++        // translate virtual addresses for NES/Famicom
++        if(platform == PLATFORM_NES){
++                int bank_number;
++                if((rrtadr0 & 0xC000) == 0xC000)
++                {
++                    // Place fixed bank as bank 0 / first bank of ROM for simpler handling
++                    // (.nes file creation will put it as the *last* bank by rotating the ROM file) 
++                    bank_number = 0;
++                    rrtadr0 = (bank_number * 0x4000) + (rrtadr0 & 0x3FFF);
++                }
++                else if((rrtadr0 & 0xC000) == 0x8000)
++                {
++                    // Place switchable bank one bank higher than intended in ROM
++                    // (.nes file creation will relocate it to correct bank by rotating the ROM file)
++                    int bank_number = (rrtadr0 >> 16) + 1;
++                    rrtadr0 = (bank_number * 0x4000) + (rrtadr0 & 0x3FFF);
++                }
++        }
++
+         max = (int) (rtadr1 - rtadr0);
+         if (max) {
+                 if (a_bytes > 2) {

--- a/Patches/0500_sdld_outofbounds_fix.patch
+++ b/Patches/0500_sdld_outofbounds_fix.patch
@@ -1,0 +1,23 @@
+Index: sdcc/sdas/linksrc/lkmem.c
+===================================================================
+--- sdcc/sdas/linksrc/lkmem.c	(revision 14068)
++++ sdcc/sdas/linksrc/lkmem.c	(working copy)
+@@ -44,7 +44,8 @@
+ 
+     char buff[128];
+     int j, toreturn=0;
+-    unsigned int Total_Last=0, k;
++    unsigned int Total_Last=0;
++    int k;
+ 
+     struct area * xp;
+     FILE * of;
+@@ -274,7 +275,7 @@
+ 
+     /*Compute the amount of unused memory in direct data Ram.  This is the
+     gap between the last register bank or bit segment and the data segment.*/
+-    for(k=Ram[6].Start-1; (dram[k]==0) && (k>0); k--);
++    for(k=Ram[6].Start-1; (k>0) && (dram[k]==0); k--);
+     Ram[5].Start=k+1;
+     Ram[5].Size=Ram[6].Start-Ram[5].Start; /*It may be zero (which is good!)*/
+ 

--- a/Patches/0600_missing_lst_fix.patch
+++ b/Patches/0600_missing_lst_fix.patch
@@ -1,0 +1,19 @@
+Index: sdcc/sdas/linksrc/lkmain.c
+===================================================================
+--- sdcc/sdas/linksrc/lkmain.c	(revision 14581)
++++ sdcc/sdas/linksrc/lkmain.c	(working copy)
+@@ -1490,8 +1490,14 @@
+ #endif
+         }
+         if ((fp = fopen(afspec, frmt)) == NULL && strcmp(ft,"adb") != 0) { /* Do not complain for optional adb files */
++            if(strcmp(ft,"lst") == 0) {
++                /* For optional lst files, just print a warning and continue */
++                fprintf(stderr, "?ASlink-Warning-<cannot %s> : \"%s\"\n", wf?"create":"open", afspec);
++            }
++            else {
+                 fprintf(stderr, "?ASlink-Error-<cannot %s> : \"%s\"\n", wf?"create":"open", afspec);
+                 lkerr++;
++            }
+         }
+         return (fp);
+ }

--- a/Patches/0700_mos6502_32bit_address.patch
+++ b/Patches/0700_mos6502_32bit_address.patch
@@ -1,0 +1,13 @@
+Index: sdcc/sdas/as6500/r65mch.c
+===================================================================
+--- sdcc/sdas/as6500/r65mch.c	(revision 14868)
++++ sdcc/sdas/as6500/r65mch.c	(working copy)
+@@ -693,7 +693,7 @@
+ 	/*
+ 	 * Address Space
+ 	 */
+-	exprmasks(3);
++	exprmasks(4);
+ 	
+ 	/*
+ 	 * Zero Page Area Pointer


### PR DESCRIPTION
- Update to SDCC 4.5.0 RC2 as default version
- Support zipped collection of ordered, non-merged patches
- Stagger matrix build jobs by 1 minute to avoid hammering sdcc subversion and being blocked
- Linux/Win-cross: work around buggy boost versions, install alternate
- Start tracking patches in repo