### PR TITLE
Patch: warn instead of err on obj file O-line mismatch

### DIFF
--- a/Patches/0800_15224_no_oline_link_error__no_sdcccall_in_oline.patch
+++ b/Patches/0800_15224_no_oline_link_error__no_sdcccall_in_oline.patch
@@ -1,0 +1,21 @@
+Index: sdcc/sdas/linksrc/lkmain.c
+===================================================================
+--- sdcc/sdas/linksrc/lkmain.c	(revision 15224)
++++ sdcc/sdas/linksrc/lkmain.c	(working copy)
+@@ -578,12 +578,13 @@
+                         }
+                         else {
+                                 if (strcmp(optsdcc, &ip[1]) != 0) {
++                                        // Emit a warning when object O lines don't match instead of erroring out
+                                         fprintf(stderr,
+-                                                "?ASlink-Warning-Conflicting sdcc options:\n"
++                                                "?ASlink-Warning O Lines in linked objects do not match:\n"
+                                                 "   \"%s\" in module \"%s\" and\n"
+                                                 "   \"%s\" in module \"%s\".\n",
+                                                 optsdcc, optsdcc_module, &ip[1], hp->m_id);
+-                                        lkerr++;
++                                        // lkerr++;
+                                 }
+                         }
+                 }
+


### PR DESCRIPTION

https://github.com/gbdk-2020/gbdk-2020/commit/4ff8549fda7d9262c38f61f2f74c75970706e40a

This omits the SDCC side of the patch (see below) and instead relies on the use of `--no-optsdcc-in-asm` added in commit https://github.com/gbdk-2020/gbdk-2020/commit/4ff8549fda7d9262c38f61f2f74c75970706e40a

```diff
Index: sdcc/src/z80/main.c
===================================================================
--- sdcc/src/z80/main.c	(revision 15224)
+++ sdcc/src/z80/main.c	(working copy)
@@ -950,7 +950,9 @@
   if (!options.noOptsdccInAsm)
     {
       tfprintf (of, "\t!optsdcc -m%s", port->target);
-      fprintf (of, " sdcccall(%d)", options.sdcccall);
+      // Remove recently added SDCC calling convention in linker file O line,
+      // this needlessly breaks linking with compatible object files
+      // fprintf (of, " sdcccall(%d)", options.sdcccall);
       fprintf (of, "\n");
     }
 }
```