### PR TITLE
Build: macos-13 runner to macos-15-intel + Use boost from Homebrew again

### DIFF
--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -39,7 +39,7 @@ jobs:
             name: Win32-On-Linux
           - os: ubuntu-22.04
             name: Win64-On-Linux
-          - os: macos-13
+          - os: macos-15-intel
             name: MacOS-x64
           - os: macos-14
             name: MacOS-arm64            

--- a/.github/workflows/sdcc_build.yml
+++ b/.github/workflows/sdcc_build.yml
@@ -69,15 +69,8 @@ jobs:
         if: (matrix.name == 'MacOS-x64') || (matrix.name == 'MacOS-arm64')
         run: |
           # Packages (some may already be present)
-          # env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install flex bison boost texinfo zlib subversion
-          # No boost 1.85.0 via homebrew since it brak sdcc
-          env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install flex bison texinfo zlib subversion
-          # manual boost install with Clang
-          wget https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz -O- | tar xfz -
-          cd boost*
-          ./bootstrap.sh --prefix=/usr/local
-          sudo ./b2 cxxflags=-std=c++17 install
-          cd ..
+          # Homebrew has updated boost to 1.89.0 which has the fix SDCC needs, so we can use theirs again (https://formulae.brew.sh/formula/boost)
+          env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install flex bison boost texinfo zlib subversion
 
       # This could be split apart to separate 32 and 64 bit, but doesn't
       # take much time and is easier to keep in sync as one stage.


### PR DESCRIPTION
macos-13 runner will be deprecated in November 2025, updating to next available x86/intel mac runner.

See https://github.com/gbdk-2020/gbdk-2020/issues/821

Homebrew boost version is now 1.89 (instead of 1.85) which has the fix SDCC needs, so use their version again instead of manually building it. It's much faster than build from source, especially on the `macos-15-intel` runner (12 vs 45 minutes).

Ref: 
- https://sourceforge.net/p/sdcc/bugs/3739/
- https://github.com/gbdk-2020/gbdk-2020-sdcc/pull/9
